### PR TITLE
Set showModal=false on modal stories

### DIFF
--- a/src/organisms/modal-drawer/stories/modal-drawer.stories.tsx
+++ b/src/organisms/modal-drawer/stories/modal-drawer.stories.tsx
@@ -9,7 +9,7 @@ export default {
 };
 
 export const ModalDrawerComponent = (args: ModalDrawerProps) => {
-  const [isShowing, setIsShowing] = useState(true);
+  const [isShowing, setIsShowing] = useState(false);
   return (
     <div>
       {!isShowing && (
@@ -60,7 +60,7 @@ ModalDrawerComponent.args = {
 };
 
 export const ModalDrawerCustomFooterComponent = (args: ModalDrawerProps) => {
-  const [isShowing, setIsShowing] = useState(true);
+  const [isShowing, setIsShowing] = useState(false);
   return (
     <div>
       {!isShowing && (

--- a/src/organisms/modal/stories/modal.stories.tsx
+++ b/src/organisms/modal/stories/modal.stories.tsx
@@ -23,11 +23,11 @@ ModalComponentBase.args = {
   title: 'Checkout',
   footer: true,
   closeValue: 'Close',
-  isShowing: true,
+  isShowing: false,
 };
 
 export const ModalEditorComponent = (args: ModalProps) => {
-  const [isShowing, setIsShowing] = useState(true);
+  const [isShowing, setIsShowing] = useState(false);
   return (
     <div>
       {!isShowing && (


### PR DESCRIPTION
https://main--600c295ccb36300021e7d82f.chromatic.com/?path=/docs/components-organisms-modal--docs

does not show the documentation for the modals because the modals are opening on component-render, but there's one that can't be closed -- so user can _never_ see the modal documentation page