### PR TITLE
[Checkbox Group] Track `Option Item` state changes

### DIFF
--- a/src/atoms/checkbox/index.tsx
+++ b/src/atoms/checkbox/index.tsx
@@ -10,10 +10,7 @@ export interface CheckboxProps {
   value: string;
   label?: string | React.ReactNode;
   checked?: boolean | undefined;
-  onChange?: (
-    event: React.ChangeEvent<HTMLInputElement>,
-    value: boolean
-  ) => void;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   error?: boolean;
   disabled?: boolean;
   className?: string;
@@ -40,7 +37,7 @@ const Checkbox = ({
   const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setIsChecked(prev => {
       const value = !prev;
-      onChange(event, value);
+      onChange(event);
       return value;
     });
   };

--- a/src/atoms/checkbox/index.tsx
+++ b/src/atoms/checkbox/index.tsx
@@ -10,7 +10,10 @@ export interface CheckboxProps {
   value: string;
   label?: string | React.ReactNode;
   checked?: boolean | undefined;
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    value: boolean
+  ) => void;
   error?: boolean;
   disabled?: boolean;
   className?: string;
@@ -35,8 +38,11 @@ const Checkbox = ({
   const [isChecked, setIsChecked] = useState(checked);
 
   const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setIsChecked(prev => !prev);
-    onChange(event);
+    setIsChecked(prev => {
+      const value = !prev;
+      onChange(event, value);
+      return value;
+    });
   };
 
   const checkmarkClassName = useMemo(() => {

--- a/src/atoms/checkbox/index.tsx
+++ b/src/atoms/checkbox/index.tsx
@@ -35,11 +35,8 @@ const Checkbox = ({
   const [isChecked, setIsChecked] = useState(checked);
 
   const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setIsChecked(prev => {
-      const value = !prev;
-      onChange(event);
-      return value;
-    });
+    setIsChecked(prev => !prev);
+    onChange(event);
   };
 
   const checkmarkClassName = useMemo(() => {

--- a/src/molecules/checkbox-group/index.tsx
+++ b/src/molecules/checkbox-group/index.tsx
@@ -6,8 +6,7 @@ import * as Styles from './styles';
 export type CheckboxItem = {
   value: string;
   label?: string | React.ReactNode;
-  checked?: boolean;
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  checked?: boolean | null;
   error?: string;
   disabled?: boolean;
   className?: string;
@@ -16,12 +15,20 @@ export type CheckboxItem = {
   required?: boolean;
 };
 
+interface CheckboxGroupItemOnChange {
+  value: string;
+  checked: boolean;
+}
 export interface CheckboxGroupProps {
   type?: 'row' | 'column';
   children?: React.ReactNode;
   options?: CheckboxItem[];
   error?: string;
-  onChange?: () => {};
+  onChange?: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    /** The option item with its latest value state */
+    option: CheckboxGroupItemOnChange
+  ) => void;
   disabled?: boolean;
 }
 
@@ -45,8 +52,13 @@ const CheckboxGroup = (props: CheckboxGroupProps) => {
               <Checkbox
                 label={value.label}
                 value={value.value}
-                checked={value.checked}
-                onChange={onChange}
+                checked={value.checked ?? undefined}
+                onChange={(event, isChecked) =>
+                  onChange?.(event, {
+                    value: value.value,
+                    checked: isChecked,
+                  })
+                }
                 error={!!error}
                 disabled={disabled}
               />

--- a/src/molecules/checkbox-group/index.tsx
+++ b/src/molecules/checkbox-group/index.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties } from 'react';
-import Checkbox from '../../atoms/checkbox';
+import Checkbox, { CheckboxProps } from '../../atoms/checkbox';
 import ErrorField from '../../atoms/error-field';
 import * as Styles from './styles';
 
@@ -7,6 +7,7 @@ export type CheckboxItem = {
   value: string;
   label?: string | React.ReactNode;
   checked?: boolean | null;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   error?: string;
   disabled?: boolean;
   className?: string;
@@ -15,22 +16,12 @@ export type CheckboxItem = {
   required?: boolean;
 };
 
-interface ICheckboxGroupItemOnChange {
-  value: string;
-  checked: boolean;
-}
-interface ICheckboxGroupOnChange {
-  event: React.ChangeEvent<HTMLInputElement>;
-  /** The option item with its latest value state */
-  option: ICheckboxGroupItemOnChange;
-}
-
 export interface CheckboxGroupProps {
   type?: 'row' | 'column';
   children?: React.ReactNode;
   options?: CheckboxItem[];
   error?: string;
-  onChange?: (data: ICheckboxGroupOnChange) => void;
+  onChange?: CheckboxProps['onChange'];
   disabled?: boolean;
 }
 
@@ -55,15 +46,10 @@ const CheckboxGroup = (props: CheckboxGroupProps) => {
                 label={value.label}
                 value={value.value}
                 checked={value.checked ?? undefined}
-                onChange={(event, isChecked) =>
-                  onChange?.({
-                    event,
-                    option: {
-                      value: value.value,
-                      checked: isChecked,
-                    },
-                  })
-                }
+                onChange={event => {
+                  onChange?.(event);
+                  value.onChange?.(event);
+                }}
                 error={!!error}
                 disabled={disabled}
               />

--- a/src/molecules/checkbox-group/index.tsx
+++ b/src/molecules/checkbox-group/index.tsx
@@ -15,20 +15,22 @@ export type CheckboxItem = {
   required?: boolean;
 };
 
-interface CheckboxGroupItemOnChange {
+interface ICheckboxGroupItemOnChange {
   value: string;
   checked: boolean;
 }
+interface ICheckboxGroupOnChange {
+  event: React.ChangeEvent<HTMLInputElement>;
+  /** The option item with its latest value state */
+  option: ICheckboxGroupItemOnChange;
+}
+
 export interface CheckboxGroupProps {
   type?: 'row' | 'column';
   children?: React.ReactNode;
   options?: CheckboxItem[];
   error?: string;
-  onChange?: (
-    event: React.ChangeEvent<HTMLInputElement>,
-    /** The option item with its latest value state */
-    option: CheckboxGroupItemOnChange
-  ) => void;
+  onChange?: (data: ICheckboxGroupOnChange) => void;
   disabled?: boolean;
 }
 
@@ -54,9 +56,12 @@ const CheckboxGroup = (props: CheckboxGroupProps) => {
                 value={value.value}
                 checked={value.checked ?? undefined}
                 onChange={(event, isChecked) =>
-                  onChange?.(event, {
-                    value: value.value,
-                    checked: isChecked,
+                  onChange?.({
+                    event,
+                    option: {
+                      value: value.value,
+                      checked: isChecked,
+                    },
                   })
                 }
                 error={!!error}

--- a/src/molecules/checkbox-group/index.tsx
+++ b/src/molecules/checkbox-group/index.tsx
@@ -7,6 +7,9 @@ export type CheckboxItem = {
   value: string;
   label?: string | React.ReactNode;
   checked?: boolean | null;
+  /** The item changes can be tracked here
+   * or inside the `CheckboxGroup' onChange`
+   */
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   error?: string;
   disabled?: boolean;
@@ -21,6 +24,9 @@ export interface CheckboxGroupProps {
   children?: React.ReactNode;
   options?: CheckboxItem[];
   error?: string;
+  /** The item changes can be tracked here
+   * or inside the `CheckboxItem' onChange`
+   */
   onChange?: CheckboxProps['onChange'];
   disabled?: boolean;
 }


### PR DESCRIPTION
Since the `CheckboxGroup` component is a list of `Checkbox` components, currently it is not possible to track the state of each item because: 

1. The `CheckboxGroup onChange` is badly typed
2. The `CheckboxItem onChange` is not being used

Now, it's possible to track the changes both from the `CheckboxGroup and CheckboxItem`, leaving the choice to the developer.