### PR TITLE
[TKAI-3494] style: improve position and overflow properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.5",
+  "version": "3.0.10-beta.1",
   "name": "@taikai/rocket-kit",
   "author": "taikai",
   "description": "TAIKAI Design System",

--- a/src/organisms/modal-drawer/styles.tsx
+++ b/src/organisms/modal-drawer/styles.tsx
@@ -39,12 +39,10 @@ export const ModalWrapper = styled.div<ModalStyleBaseProps>`
 `;
 
 export const ModalContainer = styled.div<ModalStyleBaseProps>`
-  position: fixed;
-  right: 0;
+  margin-left: auto;
   background: ${colors.white};
   width: 100%;
-  height: 100vh;
-  height: calc(var(--vh, 1vh) * 100);
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   padding: ${rem('15px')};
@@ -54,7 +52,6 @@ export const ModalContainer = styled.div<ModalStyleBaseProps>`
   animation-fill-mode: forwards;
   transform: translateX(100%);
   animation-name: ${slideInLeft};
-  overflow-y: auto;
 
   @media ${device.s} {
     max-width: ${rem('400px')};


### PR DESCRIPTION
![CleanShot 2024-01-16 at 11 41 14@2x](https://github.com/layerx-labs/rocket-kit/assets/2805206/a5e1e554-c2ed-472b-b19d-95ecec2afa64)

The problem comes when we want elements to overflow the `ModalContainer` area, such as tooltips. In this case, the `overflow-y: auto` property prevented that, and we need to deal with the wrapper's position differently to maintain the scroll when required.